### PR TITLE
Google Music: Remove bugfix for HTTPS

### DIFF
--- a/max2play/application/plugins/max2play_settings/scripts/lms_plugin_googlemusic.sh
+++ b/max2play/application/plugins/max2play_settings/scripts/lms_plugin_googlemusic.sh
@@ -22,10 +22,6 @@ git clone https://github.com/squeezebox-googlemusic/squeezebox-googlemusic.git .
 chown -R squeezeboxserver /var/lib/squeezeboxserver/Plugins/GoogleMusic
 chmod -R g+wx /var/lib/squeezeboxserver/Plugins/GoogleMusic
 
-# Bugfix for HTTPS
-echo "Apply Bugfix for HTTPS in ProtocolHandler.pm"
-sed -i 's/use base qw(Slim::Player::Protocols::HTTP);/use base qw(Slim::Player::Protocols::HTTPS);/' /var/lib/squeezeboxserver/Plugins/GoogleMusic/ProtocolHandler.pm
-
 /etc/init.d/logitechmediaserver restart
 
 echo "<b>Finished installing Google Music Plugin</b>"

--- a/max2play/application/plugins/max2play_settings/scripts/lms_plugin_googlemusic.sh
+++ b/max2play/application/plugins/max2play_settings/scripts/lms_plugin_googlemusic.sh
@@ -6,9 +6,8 @@ echo "Install Google Music as Plugin for Squeezebox Server"
 
 # Setup Environment
 apt-get update
-apt-get install python-pip python-dev -y
-pip install gmusicapi==10.0.1 
-echo -e "yes\n" | cpan App::cpanminus
+apt-get install python-pip python-dev cpanminus libio-socket-perl -y
+pip install gmusicapi==10.0.1
 cpanm --notest Inline
 cpanm --notest Inline::Python
 


### PR DESCRIPTION
The bugfix for HTTPS is no longer required as a fix was pushed to the
squeezebox-googlemusic repo as of https://github.com/squeezebox-googlemusic/squeezebox-googlemusic/commit/e11f9c1f38d8bf22f90e3ce075a524581508a252

I've also added updated the script so that `cpanminus` and `libio-socket-perl` is installed with `apt-get`. 

Installing `cpanminus` from `apt-get` instead of `cpan` fixed this issue for me while attempting to install the plugin using the max2play webinterface:

```
Running install for module 'App::cpanminus'
Checksum for /root/.cpan/sources/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7043.tar.gz ok
Uncompressed /root/.cpan/sources/authors/id/M/MI/MIYAGAWA/App-cpanminus-1.7043.tar.gz successfully
Using Tar:/bin/tar xf "App-cpanminus-1.7043.tar":
Couldn't untar App-cpanminus-1.7043.tar: 'Cannot allocate memory'
'YAML' not installed, will not store persistent state
MIYAGAWA/App-cpanminus-1.7043.tar.gz
Had problems unarchiving. Please build manually
```

And installing `libio-socket-perl` fixes this issue with the plugin:
```
[17-12-28 02:47:17.6499] Slim::bootstrap::tryModuleLoad (286) Warning: Module [Plugins::GoogleMusic::Plugin] failed to load:
Base class package "IO::Socket::SSL" is empty.
    (Perhaps you need to 'use' the module which defines that package first,
    or make that module available in @INC (@INC contains: /var/lib/squeezeboxserver/cache/_Inline/lib /var/lib/squeezeboxserver/cache/InstalledPlugins /usr/share/squeezeboxserver/CPAN/arch/5.20/arm-linux-gnueabihf-thread-multi-64int /usr/share/squeezeboxserver/CPAN/arch/5.20/arm-linux-gnueabihf-thread-multi-64int/auto /usr/share/squeezeboxserver/CPAN/arch/5.20.2/arm-linux-gnueabihf-thread-multi-64int /usr/share/squeezeboxserver/CPAN/arch/5.20.2/arm-linux-gnueabihf-thread-multi-64int/auto /usr/share/squeezeboxserver/CPAN/arch/5.20/arm-linux-gnueabihf-thread-multi-64int /usr/share/squeezeboxserver/CPAN/arch/5.20/arm-linux-gnueabihf-thread-multi-64int/auto /usr/share/squeezeboxserver/CPAN/arch/arm-linux-gnueabihf-thread-multi-64int /usr/share/squeezeboxserver/CPAN/arch/5.20 /usr/share/squeezeboxserver/lib /usr/share/squeezeboxserver/CPAN /usr/share/squeezeboxserver /usr/share/squeezeboxserver/CPAN /usr/share/squeezeboxserver /usr/sbin /etc/perl /usr/local/lib/arm-linux-gnueabihf/perl/5.20.2 /usr/local/share/perl/5.20.2 /usr/lib/arm-linux-gnueabihf/perl5/5.20 /usr/share/perl5 /usr/lib/arm-linux-gnueabihf/perl/5.20 /usr/share/perl/5.20 /usr/local/lib/site_perl .).
 at /usr/share/perl5/Slim/Player/Protocols/HTTPS.pm line 3.
BEGIN failed--compilation aborted at /usr/share/perl5/Slim/Player/Protocols/HTTPS.pm line 3.
Compilation failed in require at /usr/share/perl/5.20/base.pm line 135.
        ...propagated at /usr/share/perl/5.20/base.pm line 157.
BEGIN failed--compilation aborted at /usr/share/squeezeboxserver/Plugins/GoogleMusic/ProtocolHandler.pm line 9.
Compilation failed in require at /usr/share/squeezeboxserver/Plugins/GoogleMusic/Plugin.pm line 26.
BEGIN failed--compilation aborted at /usr/share/squeezeboxserver/Plugins/GoogleMusic/Plugin.pm line 26.
Compilation failed in require at (eval 848) line 1.
BEGIN failed--compilation aborted at (eval 848) line 1.
```