### PR TITLE
resetting activation code - email address

### DIFF
--- a/max2play/application/plugins/max2play_settings/controller/Basic.php
+++ b/max2play/application/plugins/max2play_settings/controller/Basic.php
@@ -434,6 +434,12 @@ class Basic extends Service
     public function updateEMail($email = '')
     {
         if ($this->saveConfigFileParameter('/opt/max2play/options.conf', 'email', $email)) {
+
+            if(empty($email)){
+                $this->view->message[] = _('Your email address / activation code has been reset');
+                return false;    
+            }
+         
             $this->view->message[] = _('Your eMail-address / activation code is saved.');
             if ($this->checkLicense() != false) {
                 $this->view->message[] = _('Your license is validated. Now you have access to all features and plugins.');


### PR DESCRIPTION
I wasn't able to reset my activation code on my raspberry pi. Note: I needed to 're-activate' my installation, because the previous was expired.